### PR TITLE
updated ensime.cson to include the .ensime_cache/ 

### DIFF
--- a/snippets/ensime.cson
+++ b/snippets/ensime.cson
@@ -5,4 +5,5 @@
           # Ensime specific
           .ensime
           .ensime_lucene/
+          .ensime_cache/
           """


### PR DESCRIPTION
Potential fix for 

> Ensime snippet missing ignore for .ensime_cache/ #7
